### PR TITLE
Adds support for Debian hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,10 @@
 ---
 # defaults file for libvirt
 
+# Distro-specific var overrides will take precedence if `libvirt_packages`
+# is undefined. Set it at the site level to install custom packages.
+#libvirt_packages: []
+
 libvirt_libvirtd_listen_tls: 1
 libvirt_libvirtd_listen_tcp: 0
 libvirt_libvirtd_tls_port: 0

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -6,7 +6,7 @@
   apt:
     name: "{{ item }}"
     state: present
-    update_cache: yes
+    cache_valid_time: 3600
   with_items:
     - "{{ libvirt_packages }}"
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,19 +2,16 @@
 # tasks file for libvirt
 
 - name: Include distribution specific variables
-  include_vars: "{{ ansible_distribution }}.yml"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}.yml"
+    - main.yml
   tags:
     - libvirt
 
-- include: CentOS.yml
-  when: ansible_distribution == "CentOS"
-  tags:
-    - libvirt
-
+# Install packages via apt.
 - include: Ubuntu.yml
-  when: ansible_distribution == "Ubuntu"
-  tags:
-    - libvirt
+  when: ansible_distribution in ['Debian', 'Ubuntu']
 
 - name: Create libvirt.conf configuration file
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,19 @@
 # tasks file for libvirt
 
 - name: Include distribution specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}.yml"
-    - main.yml
+  include_vars: "{{ ansible_distribution }}.yml"
   tags:
     - libvirt
+
+- name: Set libvirt service name.
+  set_fact:
+    libvirt_service_name: "{{ __libvirt_service_name }}"
+  when: libvirt_service_name is not defined
+
+- name: Set libvirt packages.
+  set_fact:
+    libvirt_packages: "{{ __libvirt_packages }}"
+  when: libvirt_packages is not defined
 
 # Install packages via apt.
 - include: Ubuntu.yml

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 # vars file for libvirt (Debian specific)
 
-libvirt_packages:
+__libvirt_packages:
   - libvirt0
 
-libvirt_service_name: libvirtd.service
+__libvirt_service_name: libvirtd.service

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,7 @@
+---
+# vars file for libvirt (Debian specific)
+
+libvirt_packages:
+  - libvirt0
+
+libvirt_service_name: libvirtd.service

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,5 +1,5 @@
 ---
 # vars file for libvirt (Ubuntu specific)
 
-libvirt_packages:
+__libvirt_packages:
   - libvirt-bin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 # vars file for libvirt
 
-libvirt_service_name: libvirt-bin
+__libvirt_service_name: libvirt-bin


### PR DESCRIPTION
Rather minor changes to the vars structure of the role so that the Debian hosts will work out of the box. These changes are targeting Debian 9 (Stretch/Sid) rather than Debian 8 (Jessie)—however, due to the judicious use of vars for package lists and even service names in the role (:+1:!), Jessie support can still be added with a few var overrides.

If the maintainer would prefer, I'd be happy to explicitly set separate vars files for various versions of Debian.

Closes #1.